### PR TITLE
Feature/20 프로필 수정 API

### DIFF
--- a/src/main/java/com/sparta/newspeed/domain/user/User.java
+++ b/src/main/java/com/sparta/newspeed/domain/user/User.java
@@ -4,6 +4,7 @@ import com.sparta.newspeed.domain.TimeStamped;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -22,4 +23,9 @@ public class User extends TimeStamped {
 
     @Column(nullable = false)
     private String password;
+
+    public void update(String newPassword, String newUsername) {
+        this.password = newPassword;
+        this.username = newUsername;
+    }
 }

--- a/src/main/java/com/sparta/newspeed/domain/user/User.java
+++ b/src/main/java/com/sparta/newspeed/domain/user/User.java
@@ -4,7 +4,6 @@ import com.sparta.newspeed.domain.TimeStamped;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter

--- a/src/main/java/com/sparta/newspeed/user/controller/UserController.java
+++ b/src/main/java/com/sparta/newspeed/user/controller/UserController.java
@@ -5,10 +5,7 @@ import com.sparta.newspeed.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,6 +24,12 @@ public class UserController {
 
     @GetMapping("/user/{id}")
     public ResponseEntity<UserResponseDto> getUser(@PathVariable Long id) {
+        UserResponseDto user = userService.getUser(id);
+        return new ResponseEntity<>(user, HttpStatus.OK);
+    }
+
+    @PutMapping("/user/{id}")
+    public ResponseEntity<UserResponseDto> updateUser(@PathVariable Long id) {
         UserResponseDto user = userService.getUser(id);
         return new ResponseEntity<>(user, HttpStatus.OK);
     }

--- a/src/main/java/com/sparta/newspeed/user/controller/UserController.java
+++ b/src/main/java/com/sparta/newspeed/user/controller/UserController.java
@@ -5,7 +5,6 @@ import com.sparta.newspeed.user.dto.UserResponseDto;
 import com.sparta.newspeed.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/sparta/newspeed/user/controller/UserController.java
+++ b/src/main/java/com/sparta/newspeed/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.sparta.newspeed.user.controller;
 import com.sparta.newspeed.user.dto.ProfileUpdateDto;
 import com.sparta.newspeed.user.dto.UserResponseDto;
 import com.sparta.newspeed.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
@@ -31,7 +32,7 @@ public class UserController {
     }
 
     @PutMapping("/user/{id}")
-    public ResponseEntity<UserResponseDto> updateUser(@PathVariable Long id, ProfileUpdateDto reqDto) {
+    public ResponseEntity<UserResponseDto> updateUser(@PathVariable Long id, @Valid ProfileUpdateDto reqDto) {
         UserResponseDto user = userService.updateUser(id, reqDto);
         return new ResponseEntity<>(user, HttpStatus.ACCEPTED);
     }

--- a/src/main/java/com/sparta/newspeed/user/controller/UserController.java
+++ b/src/main/java/com/sparta/newspeed/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.sparta.newspeed.user.controller;
 
+import com.sparta.newspeed.user.dto.ProfileUpdateDto;
 import com.sparta.newspeed.user.dto.UserResponseDto;
 import com.sparta.newspeed.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,8 +31,8 @@ public class UserController {
     }
 
     @PutMapping("/user/{id}")
-    public ResponseEntity<UserResponseDto> updateUser(@PathVariable Long id) {
-        UserResponseDto user = userService.getUser(id);
-        return new ResponseEntity<>(user, HttpStatus.OK);
+    public ResponseEntity<UserResponseDto> updateUser(@PathVariable Long id, ProfileUpdateDto reqDto) {
+        UserResponseDto user = userService.updateUser(id, reqDto);
+        return new ResponseEntity<>(user, HttpStatus.ACCEPTED);
     }
 }

--- a/src/main/java/com/sparta/newspeed/user/dto/ProfileUpdateDto.java
+++ b/src/main/java/com/sparta/newspeed/user/dto/ProfileUpdateDto.java
@@ -1,0 +1,23 @@
+package com.sparta.newspeed.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class ProfileUpdateDto {
+    @NotBlank(message = "이전 비밀번호를 알맞게 입력해 주세요.")
+    public String password;
+
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    public String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$",
+    message = "숫자, 문자, 특수문자가 1개 이상 사용되어야 함, 길이: 8 ~ 16")
+    public String newPassword;
+
+    public void initPassword(String newPassword) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/sparta/newspeed/user/service/UserService.java
+++ b/src/main/java/com/sparta/newspeed/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.sparta.newspeed.user.service;
 
+import com.sparta.newspeed.common.PasswordEncoder;
 import com.sparta.newspeed.domain.user.User;
 import com.sparta.newspeed.domain.user.UserRepository;
+import com.sparta.newspeed.user.dto.ProfileUpdateDto;
 import com.sparta.newspeed.user.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import java.util.List;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public List<UserResponseDto> getAllUsers() {
@@ -31,5 +34,33 @@ public class UserService {
                 () -> new IllegalArgumentException("해당하는 유저가 없습니다.")
         );
         return new UserResponseDto(user);
+    }
+
+    @Transactional
+    public UserResponseDto updateUser(Long id, ProfileUpdateDto reqDto) {
+        User user = userRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("해당하는 유저가 없습니다.")
+        );
+
+        checkIfPasswordMatches(user, reqDto.getPassword());
+        checkIfPasswordSameAsBefore(user, reqDto.getNewPassword());
+
+        reqDto.initPassword(passwordEncoder.encode(reqDto.getNewPassword()));
+
+        user.update(reqDto.getNewPassword(), reqDto.getUsername());
+        return new UserResponseDto(user);
+    }
+
+    // ========== 편의 메서드 ==========
+    private void checkIfPasswordMatches(User user, String password) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+    }
+
+    private void checkIfPasswordSameAsBefore(User user, String newPassword) {
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호와는 동일한 비밀번호로 변경할 수 없습니다.");
+        }
     }
 }


### PR DESCRIPTION
로그인한 사용자는 본인의 사용자 정보를 수정할 수 있습니다.

** 수정 조건

비밀번호 수정 요청 시, 본인 확인을 위해 현재 비밀번호를 입력하여 올바른 경우에만 수정이 가능합니다.
현재 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.

** 예외

비밀번호 수정 시, 본인 확인을 위해 입력한 현재 비밀번호가 일치하지 않은 경우
비밀번호 형식이 올바르지 않은 경우
현재 비밀번호와 동일한 비밀번호로 수정하는 경우

---

비밀번호 형식 로직 추가했습니다. Validation으로 값을 검증합니다.

숫자가 1개 이상
문자가 1개 이상
특수문자가 1개 이상
길이: 8 ~ 16
비밀번호가 일치하지 않은 경우, 현재 비밀번호와 동일한 비밀번호로 수정하는 경우는 예외처리로 해결했습니다.