### PR TITLE
[fix] 친구 API 충돌 수정

### DIFF
--- a/src/main/java/com/sparta/newspeed/domain/friend/FriendRepository.java
+++ b/src/main/java/com/sparta/newspeed/domain/friend/FriendRepository.java
@@ -3,7 +3,28 @@ package com.sparta.newspeed.domain.friend;
 
 import com.sparta.newspeed.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+
     Friend findByResponseUser(User jwtUser);
+
+    /*
+    * req 혹은 res 컬럼이 userId인 경우의 쿼리
+    * SELECT CASE WHEN request_user_id = {userId} THEN response_user_id
+    *             WHEN response_user_id = {userId} THEN request_user_id
+    *             END AS friendId
+    * FROM Friend
+    * WHERE status = ACCEPTED AND (request_user_id = {userId} OR response_user_id = {userId})
+    * */
+    @Query("SELECT CASE " +
+            "WHEN f.requestUser.id = :userId THEN f.responseUser.id " +
+            "WHEN f.responseUser.id = :userId then f.requestUser.id " +
+            "END AS friendId " +
+            "FROM Friend f " +
+            "WHERE f.status = :status AND (f.requestUser.id = :userId OR f.responseUser.id = :userId)")
+    List<Long> getFriendIds(@Param("userId") Long userId, @Param("status") RequestStatus status);
 }

--- a/src/main/java/com/sparta/newspeed/friend/controller/FriendController.java
+++ b/src/main/java/com/sparta/newspeed/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com.sparta.newspeed.friend.controller;
 
 import com.sparta.newspeed.domain.user.User;
+import com.sparta.newspeed.friend.dto.FriendListResponseDto;
 import com.sparta.newspeed.friend.dto.FriendRequestDto;
 import com.sparta.newspeed.friend.service.FriendService;
 import jakarta.validation.Valid;
@@ -24,6 +25,13 @@ public class FriendController {
         friendService.sendRequest(reqDto, jwtUser);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @GetMapping("/friend")
+    public ResponseEntity<FriendListResponseDto> getFriendList(@RequestAttribute("user") User jwtUser) {
+        FriendListResponseDto resDto = friendService.getFriendList(jwtUser);
+        return ResponseEntity.status(HttpStatus.OK).body(resDto);
+    }
+
 
     @PatchMapping("/friend/{id}/friend-request")
     public ResponseEntity<Void> acceptRequest(

--- a/src/main/java/com/sparta/newspeed/friend/dto/FriendListResponseDto.java
+++ b/src/main/java/com/sparta/newspeed/friend/dto/FriendListResponseDto.java
@@ -1,0 +1,21 @@
+package com.sparta.newspeed.friend.dto;
+
+import com.sparta.newspeed.user.dto.UserResponseDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class FriendListResponseDto {
+    private String httpStatusCode;
+    private String message;
+    private List<UserResponseDto> data;
+
+    public FriendListResponseDto(String httpStatusCode, String message, List<UserResponseDto> data) {
+        this.httpStatusCode = httpStatusCode;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/sparta/newspeed/friend/dto/FriendRequestDto.java
+++ b/src/main/java/com/sparta/newspeed/friend/dto/FriendRequestDto.java
@@ -1,10 +1,11 @@
 package com.sparta.newspeed.friend.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class FriendRequestDto {
-    @NotBlank
+    @NotNull
     private Long friendId;
 }

--- a/src/main/java/com/sparta/newspeed/friend/dto/FriendResponseDto.java
+++ b/src/main/java/com/sparta/newspeed/friend/dto/FriendResponseDto.java
@@ -1,0 +1,15 @@
+package com.sparta.newspeed.friend.dto;
+
+import com.sparta.newspeed.domain.friend.Friend;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FriendResponseDto {
+    private Long friendId;
+
+    public FriendResponseDto(Long friendId) {
+        this.friendId = friendId;
+    }
+}

--- a/src/main/java/com/sparta/newspeed/friend/service/FriendService.java
+++ b/src/main/java/com/sparta/newspeed/friend/service/FriendService.java
@@ -2,11 +2,16 @@ package com.sparta.newspeed.friend.service;
 
 import com.sparta.newspeed.domain.friend.Friend;
 import com.sparta.newspeed.domain.friend.FriendRepository;
+import com.sparta.newspeed.domain.friend.RequestStatus;
 import com.sparta.newspeed.domain.user.User;
 import com.sparta.newspeed.domain.user.UserRepository;
+import com.sparta.newspeed.friend.dto.FriendListResponseDto;
 import com.sparta.newspeed.friend.dto.FriendRequestDto;
+import com.sparta.newspeed.user.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +28,20 @@ public class FriendService {
         Friend friend = new Friend();
         friend.makeFriend(jwtUser, targetUser);
         friendRepository.save(friend);
+    }
+
+    public FriendListResponseDto getFriendList(User jwtUser) {
+        List<Long> friendIds = friendRepository.getFriendIds(jwtUser.getId(), RequestStatus.ACCEPTED);
+
+        List<User> friends = friendIds.stream()
+                .map(friendId -> userRepository.findById(friendId)
+                        .orElseThrow(() -> new IllegalArgumentException("친구 ID가 잘못되었습니다.")))
+                .toList();
+
+        List<UserResponseDto> resDto = friends.stream()
+                .map(UserResponseDto::new)
+                .toList();
+        return new FriendListResponseDto("200", "친구 목록 조회 완료", resDto);
     }
 
     public void acceptRequest(Long id, User jwtUser) {


### PR DESCRIPTION
- [feat] 친구 목록 조회 기능 추가
- 친구 관계가 `ACCEPTED`인 목록만 가져옵니다.
- JPQL을 사용하여 쿼리전송을 최소화하여 성능 향상.