### PR TITLE
탈퇴 시 친구 관계 상태 변경 구현

### DIFF
--- a/src/main/java/com/sparta/newspeed/domain/board/BoardRepository.java
+++ b/src/main/java/com/sparta/newspeed/domain/board/BoardRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.newspeed.domain.board;
 
+import com.sparta.newspeed.domain.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
@@ -11,5 +12,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findByUserIdIn(List<Long> userIds); // 친구 게시물 조회
     Page<Board> findByUserIdNotIn(List<Long> userIds, Pageable pageable); // 비친구 게시물 조회
     Page<Board> findAll(Pageable pageable);
+    void deleteByUser(User user);
 
 }

--- a/src/main/java/com/sparta/newspeed/domain/comment/CommentRepository.java
+++ b/src/main/java/com/sparta/newspeed/domain/comment/CommentRepository.java
@@ -1,9 +1,11 @@
 package com.sparta.newspeed.domain.comment;
 
+import com.sparta.newspeed.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByBoardId(Long BoardId);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/sparta/newspeed/domain/friend/Friend.java
+++ b/src/main/java/com/sparta/newspeed/domain/friend/Friend.java
@@ -13,17 +13,20 @@ public class Friend {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "requestUserId", nullable = false)
+    @JoinColumn(name = "request_user_id", nullable = false)
     private User requestUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "responseUserId")
+    @JoinColumn(name = "response_user_id")
     private User responseUser;
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private RequestStatus status;
 
+    public void markAsDeleted() {
+        this.status = RequestStatus.DELETED;
+    }
     public void makeFriend(User jwtUser, User targetUser) {
         this.requestUser = jwtUser;
         this.responseUser = targetUser;

--- a/src/main/java/com/sparta/newspeed/domain/friend/FriendRepository.java
+++ b/src/main/java/com/sparta/newspeed/domain/friend/FriendRepository.java
@@ -35,4 +35,10 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             "AND f.status = 'ACCEPTED'")
     List<Long> findAcceptedFriendIds(Long userId);
 
+    List<Friend> findByRequestUserOrResponseUser(User requestUser, User responseUser);
+
+
+    List<Friend> findByRequestUser(User user);
+    List<Friend> findByResponseUser(User user);
+
 }

--- a/src/main/java/com/sparta/newspeed/domain/friend/RequestStatus.java
+++ b/src/main/java/com/sparta/newspeed/domain/friend/RequestStatus.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum RequestStatus {
-    ACCEPTED, //친구 요청 대기 중
-    PENDING, //친구 관계 성립
+    ACCEPTED, //친구 관계 성립
+    PENDING, //친구 요청 대기 중
     DELETED //친구 관계 중단 (탈퇴로 비활성화 상태)
 }

--- a/src/main/java/com/sparta/newspeed/domain/friend/RequestStatus.java
+++ b/src/main/java/com/sparta/newspeed/domain/friend/RequestStatus.java
@@ -4,5 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum RequestStatus {
-    ACCEPTED, PENDING
+    ACCEPTED, //친구 요청 대기 중
+    PENDING, //친구 관계 성립
+    DELETED //친구 관계 중단 (탈퇴로 비활성화 상태)
 }

--- a/src/main/java/com/sparta/newspeed/domain/like/boardLike/BoardLike.java
+++ b/src/main/java/com/sparta/newspeed/domain/like/boardLike/BoardLike.java
@@ -15,11 +15,11 @@ public class BoardLike {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "boardId")
+    @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
     @ManyToOne
-    @JoinColumn(name = "userId")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     private BoardLike(Board board, User user) {

--- a/src/main/java/com/sparta/newspeed/domain/user/User.java
+++ b/src/main/java/com/sparta/newspeed/domain/user/User.java
@@ -33,10 +33,12 @@ public class User extends TimeStamped {
 
     @Enumerated(EnumType.STRING)
     private UserRole role;
-  
+
+    //유저의 활성/탈퇴 여부 관리
     @Column(nullable = false)
     private boolean active = true;
 
+    //탈퇴일 기록
     private LocalDateTime deleteDate;
   
     public void signup(String email, String password, String username, UserRole role) {
@@ -55,4 +57,10 @@ public class User extends TimeStamped {
         this.deleteDate = LocalDateTime.now();
         this.active = false;
     }
+
+    // 유저 활성 상태 체크
+    public boolean isActive() {
+        return this.active;
+    }
+
 }

--- a/src/main/java/com/sparta/newspeed/domain/user/UserStatus.java
+++ b/src/main/java/com/sparta/newspeed/domain/user/UserStatus.java
@@ -1,0 +1,7 @@
+package com.sparta.newspeed.domain.user;
+
+public enum UserStatus {
+    ACTIVE,   // 유저 활성 상태
+    DELETED   // 유저 탈퇴 상태
+}
+

--- a/src/main/java/com/sparta/newspeed/friend/service/FriendService.java
+++ b/src/main/java/com/sparta/newspeed/friend/service/FriendService.java
@@ -7,6 +7,8 @@ import com.sparta.newspeed.domain.friend.FriendRepository;
 import com.sparta.newspeed.domain.friend.RequestStatus;
 import com.sparta.newspeed.domain.user.User;
 import com.sparta.newspeed.domain.user.UserRepository;
+import com.sparta.newspeed.domain.comment.CommentRepository;
+import com.sparta.newspeed.domain.board.BoardRepository;
 import com.sparta.newspeed.friend.dto.FriendDefaultResponseDto;
 import com.sparta.newspeed.friend.dto.FriendListResponseDto;
 import com.sparta.newspeed.friend.dto.FriendRequestDto;
@@ -25,6 +27,8 @@ public class FriendService {
 
     private final UserRepository userRepository;
     private final FriendRepository friendRepository;
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
 
     public FriendDefaultResponseDto sendRequest(FriendRequestDto reqDto, User jwtUser) {
         User targetUser = findRequestUser(reqDto.getFriendId());
@@ -46,6 +50,28 @@ public class FriendService {
 
         return new FriendListResponseDto("200", "친구 목록 조회 완료", friends);
     }
+
+    @Transactional
+    public void handleUserDeletion(User user) {
+        // 요청한 사용자와 응답한 사용자 모두를 고려하여 친구 관계를 DELETED 상태로 변경
+        List<Friend> requestFriends = friendRepository.findByRequestUser(user);
+        List<Friend> responseFriends = friendRepository.findByResponseUser(user);
+
+        // DELETED 상태로 변경
+        requestFriends.forEach(Friend::markAsDeleted);
+        responseFriends.forEach(Friend::markAsDeleted);
+
+        friendRepository.saveAll(requestFriends);
+        friendRepository.saveAll(responseFriends);
+
+        // 게시글과 댓글 삭제
+        boardRepository.deleteByUser(user);
+        commentRepository.deleteByUser(user);
+
+        // 유저 삭제
+        userRepository.delete(user);
+    }
+
 
     @Transactional
     public FriendDefaultResponseDto acceptRequest(Long id, User jwtUser) {

--- a/src/main/java/com/sparta/newspeed/user/controller/UserController.java
+++ b/src/main/java/com/sparta/newspeed/user/controller/UserController.java
@@ -56,6 +56,6 @@ public class UserController {
     @DeleteMapping("/user")
     public ResponseEntity<Void> deleteUser(@Valid @RequestBody DeleteRequestDto reqDto, @RequestAttribute("user") User jwtUser) {
         userService.deleteUser(reqDto, jwtUser);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent().build(); //상태 코드 204 반환
     }
 }


### PR DESCRIPTION
- 친구 관계에서 한쪽이 탈퇴한 경우
  - friends 테이블의 상태를 DELETED로 변경
  - 친구 목록 조회 시 RequestStatus.DELETED 상태의 친구는 조회되지 않도록 필터링

- 회원 탈퇴 시
  - 해당 유저의 게시글과 댓글 삭제